### PR TITLE
Clear focus on EditText when back is pressed/swiped

### DIFF
--- a/app/src/main/java/com/omgodse/notally/activities/MakeList.kt
+++ b/app/src/main/java/com/omgodse/notally/activities/MakeList.kt
@@ -71,10 +71,8 @@ class MakeList : NotallyActivity(Type.LIST) {
     override fun configureUI() {
         binding.EnterTitle.setOnNextAction { listManager.moveFocusToNext(-1) }
 
-        if (model.isNewNote) {
-            if (model.items.isEmpty()) {
-                listManager.add(pushChange = false)
-            }
+        if (model.isNewNote || model.items.isEmpty()) {
+            listManager.add(pushChange = false)
         }
     }
 

--- a/app/src/main/java/com/omgodse/notally/miscellaneous/EditTextAutoClearFocus.kt
+++ b/app/src/main/java/com/omgodse/notally/miscellaneous/EditTextAutoClearFocus.kt
@@ -1,0 +1,17 @@
+package com.omgodse.notally.miscellaneous
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.KeyEvent
+import androidx.appcompat.widget.AppCompatEditText
+
+class EditTextAutoClearFocus(context: Context, attributeSet: AttributeSet) :
+    AppCompatEditText(context, attributeSet) {
+
+    override fun onKeyPreIme(keyCode: Int, event: KeyEvent): Boolean {
+        if (keyCode == KeyEvent.KEYCODE_BACK && event.action == KeyEvent.ACTION_UP) {
+            this.clearFocus()
+        }
+        return super.onKeyPreIme(keyCode, event)
+    }
+}

--- a/app/src/main/java/com/omgodse/notally/recyclerview/viewholder/MakeListVH.kt
+++ b/app/src/main/java/com/omgodse/notally/recyclerview/viewholder/MakeListVH.kt
@@ -68,7 +68,7 @@ class MakeListVH(
     }
 
     fun focusEditText(
-        selectionStart: Int = binding.EditText.text.length,
+        selectionStart: Int = binding.EditText.text!!.length,
         inputMethodManager: InputMethodManager,
     ) {
         binding.EditText.requestFocus()

--- a/app/src/main/res/layout/recycler_list_item.xml
+++ b/app/src/main/res/layout/recycler_list_item.xml
@@ -53,7 +53,7 @@
             android:minWidth="0dp"
             android:minHeight="0dp" />
 
-        <EditText
+        <com.omgodse.notally.miscellaneous.EditTextAutoClearFocus
             android:id="@+id/EditText"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"


### PR DESCRIPTION
Fixes #19 
* When keyboard is open, 1st swipe back closes keyboard, 2nd swipe navigates back
* Same behaviour with Android back button

[notally_swipe_back.webm](https://github.com/user-attachments/assets/b13c6872-1719-42e6-9fb8-15debf0e4788)
